### PR TITLE
New gadget bar

### DIFF
--- a/gadgets/clock/src/lib.rs
+++ b/gadgets/clock/src/lib.rs
@@ -2,7 +2,9 @@ use chrono::Local;
 use egui::RichText;
 use utils::{Gadget, GadgetFactory};
 
-pub struct ClockGadget(usize);
+pub struct ClockGadget {
+    id: usize,
+}
 
 pub struct ClockGadgetFactory;
 
@@ -14,7 +16,7 @@ impl Gadget for ClockGadget {
     fn render(&mut self, ctx: &egui::Context) {
         egui::Window::new("Clock")
             .resizable(false)
-            .id(self.make_id(self.0))
+            .id(self.make_id(self.id))
             .show(ctx, |ui| {
                 let now = Local::now();
                 let text = RichText::new(now.format("%H:%M").to_string()).size(64.0);
@@ -34,6 +36,6 @@ impl GadgetFactory for ClockGadgetFactory {
         _egui_ctx: &egui::Context,
         id: usize,
     ) -> Box<dyn Gadget> {
-        Box::new(ClockGadget(id))
+        Box::new(ClockGadget { id })
     }
 }

--- a/gadgets/clock/src/lib.rs
+++ b/gadgets/clock/src/lib.rs
@@ -2,7 +2,7 @@ use chrono::Local;
 use egui::RichText;
 use utils::{Gadget, GadgetFactory};
 
-pub struct ClockGadget;
+pub struct ClockGadget(usize);
 
 pub struct ClockGadgetFactory;
 
@@ -12,11 +12,14 @@ impl Gadget for ClockGadget {
     }
 
     fn render(&mut self, ctx: &egui::Context) {
-        egui::Window::new("Clock").resizable(false).show(ctx, |ui| {
-            let now = Local::now();
-            let text = RichText::new(now.format("%H:%M").to_string()).size(64.0);
-            ui.label(text);
-        });
+        egui::Window::new("Clock")
+            .resizable(false)
+            .id(self.make_id(self.0))
+            .show(ctx, |ui| {
+                let now = Local::now();
+                let text = RichText::new(now.format("%H:%M").to_string()).size(64.0);
+                ui.label(text);
+            });
     }
 }
 
@@ -29,7 +32,8 @@ impl GadgetFactory for ClockGadgetFactory {
         &self,
         _network_runtime: &utils::NetworkRuntime,
         _egui_ctx: &egui::Context,
+        id: usize,
     ) -> Box<dyn Gadget> {
-        Box::new(ClockGadget)
+        Box::new(ClockGadget(id))
     }
 }

--- a/gadgets/cses-status/src/lib.rs
+++ b/gadgets/cses-status/src/lib.rs
@@ -8,6 +8,7 @@ use utils::{Gadget, GadgetFactory, MutexExt};
 mod cses_query;
 
 pub struct CSESStatusGadget {
+    id: usize,
     problem_data: ProblemData,
     network_runtime: utils::NetworkRuntime,
     should_ask_for_id: bool,
@@ -58,6 +59,7 @@ impl Gadget for CSESStatusGadget {
 
     fn render(&mut self, ctx: &egui::Context) {
         egui::Window::new("CSES Status")
+            .id(self.make_id(self.id))
             .min_width(200.0)
             .show(ctx, |ui| {
                 egui::ScrollArea::vertical().show(ui, |ui| {
@@ -82,8 +84,10 @@ impl GadgetFactory for CSESStatusGadgetFactory {
         &self,
         network_runtime: &utils::NetworkRuntime,
         egui_ctx: &egui::Context,
+        id: usize,
     ) -> Box<dyn Gadget> {
         let mut cses_status_gadget = CSESStatusGadget {
+            id,
             problem_data: Arc::new(Mutex::new(vec![])),
             network_runtime: network_runtime.clone(),
             should_ask_for_id: false,

--- a/gadgets/safebooru-waifu/src/lib.rs
+++ b/gadgets/safebooru-waifu/src/lib.rs
@@ -7,6 +7,7 @@ use utils::{Gadget, GadgetFactory, MutexExt};
 mod safebooru;
 
 pub struct WaifuGadget {
+    id: usize,
     image: Arc<Mutex<Option<ImageWithMetadata>>>,
 }
 
@@ -18,11 +19,13 @@ impl Gadget for WaifuGadget {
     }
 
     fn render(&mut self, ctx: &egui::Context) {
-        egui::Window::new("Your daily waifu").show(ctx, |ui| {
-            if let Some(image_with_metadata) = &*self.image.locked() {
-                render_waifu(ui, image_with_metadata);
-            }
-        });
+        egui::Window::new("Your daily waifu")
+            .id(self.make_id(self.id))
+            .show(ctx, |ui| {
+                if let Some(image_with_metadata) = &*self.image.locked() {
+                    render_waifu(ui, image_with_metadata);
+                }
+            });
     }
 }
 
@@ -35,8 +38,10 @@ impl GadgetFactory for WaifuGadgetFactory {
         &self,
         network_runtime: &utils::NetworkRuntime,
         egui_ctx: &egui::Context,
+        id: usize,
     ) -> Box<dyn Gadget> {
         let waifu_gadget = WaifuGadget {
+            id,
             image: Arc::default(),
         };
 

--- a/gadgets/weather/src/lib.rs
+++ b/gadgets/weather/src/lib.rs
@@ -11,6 +11,7 @@ use wttr::WeatherResponse;
 mod wttr;
 
 pub struct WeatherGadget {
+    id: usize,
     weather_data: Arc<Mutex<WeatherData>>,
 }
 
@@ -44,6 +45,7 @@ impl Gadget for WeatherGadget {
 
         egui::Window::new("Weather")
             .resizable(false)
+            .id(self.make_id(self.id))
             .show(ctx, |ui| {
                 ui.label(RichText::new(format!("{temperature}°C | {feels_like}°C")).size(64.0));
 
@@ -66,8 +68,10 @@ impl GadgetFactory for WeatherGadgetFactory {
         &self,
         network_runtime: &utils::NetworkRuntime,
         egui_ctx: &egui::Context,
+        id: usize,
     ) -> Box<dyn Gadget> {
         let weather_gadget = WeatherGadget {
+            id,
             weather_data: Arc::new(Mutex::new(WeatherData::default())),
         };
 

--- a/src/gadgets.rs
+++ b/src/gadgets.rs
@@ -1,6 +1,6 @@
 use utils::GadgetFactory;
 
-pub const GADGET_FACTORIES: &[&dyn GadgetFactory] = &[
+pub static GADGET_FACTORIES: &[&(dyn GadgetFactory + Sync)] = &[
     #[cfg(feature = "clock")]
     &clock::ClockGadgetFactory,
     #[cfg(feature = "weather")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,7 +50,7 @@ impl eframe::App for StarboardApp {
             self.search_bar.toggle();
         }
 
-        self.search_bar.draw(ctx);
+        self.search_bar.update(ctx);
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,14 @@
 use app_background::AppBackground;
+use search_bar::SearchBar;
 use utils::{Drawable, Gadget, NetworkRuntime};
 
 mod app_background;
 mod gadgets;
+mod search_bar;
 
 pub struct StarboardApp {
     background: AppBackground,
+    search_bar: SearchBar,
     gadgets: Vec<Box<dyn Gadget>>,
 }
 
@@ -21,6 +24,7 @@ impl StarboardApp {
 
         Self {
             background: AppBackground::default(),
+            search_bar: SearchBar::default(),
             gadgets,
         }
     }
@@ -37,6 +41,16 @@ impl eframe::App for StarboardApp {
         for gadget in &mut self.gadgets {
             gadget.render(ctx);
         }
+
+        // modifiers.command returns true if Ctrl is down in Windows / Linux
+        // or Command is down in MacOS
+        let ctrl_down = ctx.input().modifiers.command;
+        let enter_down = ctx.input().key_pressed(egui::Key::Enter);
+        if ctrl_down && enter_down {
+            self.search_bar.toggle();
+        }
+
+        self.search_bar.draw(ctx);
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,25 +7,22 @@ mod gadgets;
 mod search_bar;
 
 pub struct StarboardApp {
+    network_runtime: NetworkRuntime,
+
     background: AppBackground,
     search_bar: SearchBar,
     gadgets: Vec<Box<dyn Gadget>>,
 }
 
 impl StarboardApp {
-    fn new(egui_ctx: &egui::Context) -> Self {
+    fn new(_egui_ctx: &egui::Context) -> Self {
         let network_runtime = setup_network_runtime();
-        let mut gadgets = vec![];
-
-        // FIXME: Also allow users to spawn gadgets as they wish in the UI
-        for gadget_factory in gadgets::GADGET_FACTORIES {
-            gadgets.push(gadget_factory.make_gadget(&network_runtime, egui_ctx));
-        }
 
         Self {
+            network_runtime,
             background: AppBackground::default(),
             search_bar: SearchBar::default(),
-            gadgets,
+            gadgets: vec![],
         }
     }
 }
@@ -51,6 +48,12 @@ impl eframe::App for StarboardApp {
         }
 
         self.search_bar.update(ctx);
+
+        if let Some(factory) = self.search_bar.add_gadget {
+            self.gadgets
+                .push(factory.make_gadget(&self.network_runtime, ctx));
+            self.search_bar.add_gadget = None;
+        }
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ mod gadgets;
 mod search_bar;
 
 pub struct StarboardApp {
+    current_id: usize,
     network_runtime: NetworkRuntime,
 
     background: AppBackground,
@@ -19,6 +20,7 @@ impl StarboardApp {
         let network_runtime = setup_network_runtime();
 
         Self {
+            current_id: 0,
             network_runtime,
             background: AppBackground::default(),
             search_bar: SearchBar::default(),
@@ -51,7 +53,8 @@ impl eframe::App for StarboardApp {
 
         if let Some(factory) = self.search_bar.add_gadget {
             self.gadgets
-                .push(factory.make_gadget(&self.network_runtime, ctx));
+                .push(factory.make_gadget(&self.network_runtime, ctx, self.current_id));
+            self.current_id += 1;
             self.search_bar.add_gadget = None;
         }
     }

--- a/src/search_bar.rs
+++ b/src/search_bar.rs
@@ -6,7 +6,6 @@ use crate::gadgets;
 #[derive(Default)]
 pub struct SearchBar {
     is_open: bool,
-    is_first_frame: bool,
     search_query: String,
     selected: usize,
 
@@ -20,7 +19,7 @@ impl SearchBar {
             self.close();
         } else {
             self.is_open = true;
-            self.is_first_frame = true;
+            self.update_matching_gadgets();
         }
     }
 
@@ -75,20 +74,9 @@ impl SearchBar {
             return;
         }
 
-        if edit_response.changed() || self.is_first_frame {
+        if edit_response.changed() {
             // TODO: Use fuzzy matching instead
-            self.matching_gadgets = gadgets::GADGET_FACTORIES
-                .iter()
-                .copied()
-                .filter(|gadget| {
-                    gadget
-                        .gadget_name()
-                        .to_lowercase()
-                        .contains(&self.search_query.to_lowercase())
-                })
-                .collect();
-
-            self.is_first_frame = false;
+            self.update_matching_gadgets();
             self.selected = self
                 .selected
                 .clamp(0, self.matching_gadgets.len().saturating_sub(1));
@@ -108,6 +96,19 @@ impl SearchBar {
         }
 
         edit_response.request_focus();
+    }
+
+    fn update_matching_gadgets(&mut self) {
+        self.matching_gadgets = gadgets::GADGET_FACTORIES
+            .iter()
+            .copied()
+            .filter(|gadget| {
+                gadget
+                    .gadget_name()
+                    .to_lowercase()
+                    .contains(&self.search_query.to_lowercase())
+            })
+            .collect();
     }
 
     fn select_next(&mut self) {

--- a/src/search_bar.rs
+++ b/src/search_bar.rs
@@ -1,4 +1,4 @@
-use egui::{Color32, Key, TextStyle};
+use egui::{Color32, Key, ScrollArea, TextStyle};
 use utils::GadgetFactory;
 
 use crate::gadgets;
@@ -8,6 +8,7 @@ pub struct SearchBar {
     is_open: bool,
     is_first_frame: bool,
     search_query: String,
+    selected: usize,
 
     matching_gadgets: Vec<&'static (dyn GadgetFactory + Sync)>,
 }
@@ -37,9 +38,21 @@ impl SearchBar {
         let response = ui.text_edit_singleline(&mut self.search_query);
         self.handle_input(ui, &response);
 
-        for gadget in self.matching_gadgets.iter() {
-            ui.label(gadget.gadget_name());
-        }
+        ScrollArea::vertical().show_rows(
+            ui,
+            ui.text_style_height(&TextStyle::Heading),
+            self.matching_gadgets.len(),
+            |ui, row_range| {
+                for row in row_range {
+                    if row == self.selected {
+                        ui.colored_label(Color32::YELLOW, self.matching_gadgets[row].gadget_name())
+                            .scroll_to_me(None);
+                    } else {
+                        ui.label(self.matching_gadgets[row].gadget_name());
+                    }
+                }
+            },
+        );
 
         if self.matching_gadgets.is_empty() {
             ui.colored_label(Color32::RED, "Could not find any gadget");
@@ -49,9 +62,8 @@ impl SearchBar {
     fn handle_input(&mut self, ui: &egui::Ui, edit_response: &egui::Response) {
         let pressed_tab = ui.input().key_pressed(Key::Tab);
         let pressed_enter = ui.input().key_pressed(Key::Enter);
+        let pressed_shift = ui.input().modifiers.shift;
         let should_close = edit_response.lost_focus() && !pressed_tab && !pressed_enter;
-        // TODO: Show current selection
-        // TODO: Handle tab and shift-tab for changing selection
         // TODO: Handle enter for opening selected gadget
 
         if should_close {
@@ -67,8 +79,32 @@ impl SearchBar {
                 .collect();
 
             self.is_first_frame = false;
+            self.selected = self.selected.clamp(0, self.matching_gadgets.len() - 1);
+        }
+
+        if (pressed_tab && !pressed_shift) || ui.input().key_pressed(Key::ArrowDown) {
+            self.select_next();
+        }
+        if (pressed_tab && pressed_shift) || ui.input().key_pressed(Key::ArrowUp) {
+            self.select_prev();
         }
 
         edit_response.request_focus();
+    }
+
+    fn select_next(&mut self) {
+        if self.selected + 1 >= self.matching_gadgets.len() {
+            self.selected = 0;
+        } else {
+            self.selected += 1;
+        }
+    }
+
+    fn select_prev(&mut self) {
+        if self.selected == 0 {
+            self.selected = self.matching_gadgets.len().saturating_sub(1);
+        } else {
+            self.selected -= 1;
+        }
     }
 }

--- a/src/search_bar.rs
+++ b/src/search_bar.rs
@@ -1,0 +1,22 @@
+#[derive(Default)]
+pub struct SearchBar {
+    is_open: bool,
+}
+
+impl SearchBar {
+    pub fn toggle(&mut self) {
+        self.is_open = !self.is_open;
+    }
+
+    pub fn draw(&mut self, ctx: &egui::Context) {
+        if self.is_open {
+            egui::Window::new("search-bar")
+                .anchor(egui::Align2::CENTER_CENTER, [0.0, 0.0])
+                .resizable(false)
+                .title_bar(false)
+                .show(ctx, |ui| {
+                    ui.heading("test");
+                });
+        }
+    }
+}

--- a/src/search_bar.rs
+++ b/src/search_bar.rs
@@ -1,6 +1,11 @@
+use egui::Color32;
+
+use crate::gadgets;
+
 #[derive(Default)]
 pub struct SearchBar {
     is_open: bool,
+    search_query: String,
 }
 
 impl SearchBar {
@@ -8,15 +13,38 @@ impl SearchBar {
         self.is_open = !self.is_open;
     }
 
-    pub fn draw(&mut self, ctx: &egui::Context) {
-        if self.is_open {
-            egui::Window::new("search-bar")
-                .anchor(egui::Align2::CENTER_CENTER, [0.0, 0.0])
-                .resizable(false)
-                .title_bar(false)
-                .show(ctx, |ui| {
-                    ui.heading("test");
-                });
+    pub fn update(&mut self, ctx: &egui::Context) {
+        if !self.is_open {
+            return;
+        }
+
+        egui::Window::new("search-bar")
+            .anchor(egui::Align2::CENTER_CENTER, [0.0, 0.0])
+            .resizable(false)
+            .title_bar(false)
+            .show(ctx, |ui| {
+                ui.vertical_centered_justified(|ui| self.draw_search_bar(ui));
+            });
+    }
+
+    fn draw_search_bar(&mut self, ui: &mut egui::Ui) {
+        ui.text_edit_singleline(&mut self.search_query);
+        let possible_gadgets = gadgets::GADGET_FACTORIES.iter().filter_map(|gadget| {
+            if gadget.gadget_name().starts_with(&self.search_query) {
+                Some(gadget.gadget_name())
+            } else {
+                None
+            }
+        });
+
+        let mut any_matched = false;
+        for gadget in possible_gadgets {
+            any_matched = true;
+            ui.label(gadget);
+        }
+
+        if !any_matched {
+            ui.colored_label(Color32::RED, "Could not find any gadget");
         }
     }
 }

--- a/src/search_bar.rs
+++ b/src/search_bar.rs
@@ -1,4 +1,4 @@
-use egui::Color32;
+use egui::{Color32, Key};
 
 use crate::gadgets;
 
@@ -28,7 +28,9 @@ impl SearchBar {
     }
 
     fn draw_search_bar(&mut self, ui: &mut egui::Ui) {
-        ui.text_edit_singleline(&mut self.search_query);
+        let response = ui.text_edit_singleline(&mut self.search_query);
+        self.handle_input(ui, &response);
+
         let possible_gadgets = gadgets::GADGET_FACTORIES.iter().filter_map(|gadget| {
             if gadget.gadget_name().starts_with(&self.search_query) {
                 Some(gadget.gadget_name())
@@ -46,5 +48,21 @@ impl SearchBar {
         if !any_matched {
             ui.colored_label(Color32::RED, "Could not find any gadget");
         }
+    }
+
+    fn handle_input(&mut self, ui: &egui::Ui, edit_response: &egui::Response) {
+        let pressed_tab = ui.input().key_pressed(Key::Tab);
+        let pressed_enter = ui.input().key_pressed(Key::Enter);
+        let should_close = edit_response.lost_focus() && !pressed_tab && !pressed_enter;
+        // TODO: Show current selection
+        // TODO: Handle tab and shift-tab for changing selection
+        // TODO: Handle enter for opening selected gadget
+
+        if should_close {
+            self.is_open = false;
+            return;
+        }
+
+        edit_response.request_focus();
     }
 }

--- a/utils/src/gadget.rs
+++ b/utils/src/gadget.rs
@@ -8,6 +8,10 @@ pub trait Gadget {
     /// An id representing your gadget to be used in config sections or the filesystem
     fn id(&self) -> &'static str;
 
+    fn make_id(&self, id: usize) -> egui::Id {
+        egui::Id::new(format!("{}-{id}", self.id()))
+    }
+
     fn render(&mut self, ctx: &egui::Context);
 }
 
@@ -23,6 +27,7 @@ pub trait GadgetFactory {
         &self,
         network_runtime: &NetworkRuntime,
         egui_ctx: &egui::Context,
+        id: usize,
     ) -> Box<dyn Gadget>;
 }
 


### PR DESCRIPTION
This PR enables the possibility for the user to open up new gadgets on demand, and not only at startup.

For this, pressing Ctrl + Enter opens a rofi-like menu, which displays all the enabled widgets which match the user query, after which they can select and open the one they want.

Example in action:
![2022-10-18_14-31](https://user-images.githubusercontent.com/43870496/196503051-ef484b9e-48be-4fa2-8d92-26dad5060ca8.png)

![2022-10-18_14-31_1](https://user-images.githubusercontent.com/43870496/196503123-2ce9840c-1be7-484f-85ef-e6bf5359d4f1.png)


Since this is the first time we have open more than one type of gadget, I also had to implement a way to give each and every window an unique identifier.